### PR TITLE
Rebuilt addtions for poi Info and verified.

### DIFF
--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -858,6 +858,8 @@ end
 -->}
 function lib:GetZoneMapPinInfo(zoneId, parentZoneId)
 	if zoneId == nil or type(zoneId) ~= 'number' then return end
+	parentZoneId = parentZoneId or GetParentZoneId(zoneId)
+	
 	local zoneInfo = self.zoneData[zoneId]
 	if not zoneInfo then return end
 	local mapInfo = zoneInfo.mapInfo

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -406,6 +406,8 @@ function lib:GetAllZoneDataById(reBuildNew, doReloadUI)
             end
         end
     end
+	-- Clear the poiDataTable
+	poiDataTable = nil
     --Was at least one zoneId added/changed?
     if addedAtLeastOne then
         --Update the API version as the zoneIds check was done

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -924,6 +924,13 @@ function lib:GetZoneGeogrphicalParentZoneId(zoneId)
 	return parentZoneId
 end
 
+-->return: number: parentMapId
+function lib:GetZoneGeogrphicalParentMapId(zoneId)
+	local parentZoneId = lib:GetZoneGeogrphicalParentZoneId(zoneId)
+	
+	return GetMapIdByZoneId(parentZoneId)
+end
+
 ------------------------------------------------------------------------
 -- 	Addon/Librray load functions
 ------------------------------------------------------------------------

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -243,7 +243,7 @@ end
 -->			['poiZoneIndex'] = number,
 -->		},
 -->}
-local function getMapInfo(zoneId)
+local function getPinInfo(zoneId)
 	local mapInfo
 	--Get poiIndices for zoneId
 	local pinInfo = lib.poiRefrenceTable[zoneId]
@@ -376,10 +376,10 @@ function lib:GetAllZoneDataById(reBuildNew, doReloadUI)
                     end
                 end
 		-- Get mapInfo.
-		local mapInfo = getMapInfo(zoneId)
+		local pinInfo = getPinInfo(zoneId)
 		-- If mapInfo then add it to zone data.
-		if mapInfo then
-			zoneDataForId.mapInfo = mapInfo
+		if pinInfo then
+			zoneDataForId.pinInfo = pinInfo
 		end
             end
         end

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -118,22 +118,6 @@ local function checkOtherLanguagesZoneDataAndTransferFromSavedVariables()
     end
 end
 
--- This table contains parentZoneId modifiers for select zones.
-local geographicalParentZoneId = {
-	[678] = 181, -- Imperial City Prison, force the use of Cyrodiil
-	[688] = 181, -- White-Gold Tower, force the use of Cyrodiil
-	[1027] = 1027, -- Artaeum. Normally is Summerset.
-	[1283] = 1283, -- The Shambles. Normally is Fargrave  City District.
---	[1283] = 1283, -- Fargrave. set to use Faregrave instead of Fargrave City District.
-	
-	-- The parentZoneId for the following normally are the same as zoneId.
-	[1005] = 823, -- Linchal Grand Manor
-	[1108] = 726, -- Lakemire Xanmeer Manor.
-	[1200] = 92, -- Thieves' Oasis.
-	[1264] = 1207, -- Stone Eagle Aerie
-	[1109] = 101, -- Enchanted Snow Globe
-	[1125] = 101, -- Frostvault Chasm
-}
 --Build the data table for poi indices to be added to subzone data.
 -- Creates table:
 -- poiDataTable = {
@@ -144,7 +128,6 @@ local geographicalParentZoneId = {
 --			}
 --    },
 --}
-local wayShrineString = GetString(SI_DEATH_PROMPT_WAYSHRINE)
 local function buildPoiDataTable()
 	-- The initial data is for zones that do not match up properly by name.
 	poiDataTable = {

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -933,9 +933,9 @@ end
 -->return: number: parentMapId
 function lib:GetGeogrphicalParentMapId(mapId)
 	local zoneIndex, = select(4, GetMapInfoById(mapId))
-	local parentZoneId = lib:GetZoneGeogrphicalParentZoneId(GetZoneId(zoneIndex))
-	return GetMapIdByZoneId(parentZoneId)
+	return lib:GetZoneGeogrphicalParentMapId(GetZoneId(zoneIndex))
 end
+
 
 ------------------------------------------------------------------------
 -- 	Addon/Librray load functions

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -349,6 +349,8 @@ function lib:GetAllZoneDataById(reBuildNew, doReloadUI)
     if preloadedZoneNamesTable == nil then
         languageIsMissingInTotal = true
     end
+	-- Create the table used to add poiInfo to zoneData
+	buildPoiDataTable()
     --d(">languageIsMissingInTotal: " ..tostring(languageIsMissingInTotal))
     --Loop over all zone Ids and get it's data + name
     local addedAtLeastOne = false

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -155,6 +155,7 @@ local function buildPoiDataTable()
 	-- The initial entries are to add parentZoneId adjustments to zones without pins on parentZone.
 	poiDataTable = {
 		[GetZoneNameById(1027):lower()] = {[1027] = false},-- Artaeum. Normally is Summerset.
+		[GetZoneNameById(1282):lower()] = {[1283] = false},-- Fargrave. Normally is Fargrave City District.
 		[GetZoneNameById(1283):lower()] = {[1283] = false},-- The Shambles. Normally is Fargrave City District.
 	}
 	

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -919,6 +919,7 @@ function lib:GetZoneGeographicalParentZoneId(zoneId)
 	if zoneId == nil or type(zoneId) ~= 'number' then return end
 	local zoneInfo = lib.adjustedParentMultiZoneIds[zoneId]
 	
+	local parentZoneId
 	if zoneInfo then
 		-- This zone exists in multiple zones, if player is in parent zone then use it or use first entry.
 		local currentZoneId = GetUnitWorldPosition("player")
@@ -926,7 +927,7 @@ function lib:GetZoneGeographicalParentZoneId(zoneId)
 	end
 	
 	if not parentZoneId then
-		parentZoneId = lib:GetZoneMapPinInfo(zoneId)
+		parentZoneId = lib.adjustedParentZoneIds[zoneId] or lib:GetZoneMapPinInfo(zoneId)
 	end
 	
 	return parentZoneId
@@ -945,7 +946,6 @@ function lib:GetGeographicalParentMapId(mapId)
 	local zoneIndex = select(4, GetMapInfoById(mapId))
 	return lib:GetZoneGeographicalParentMapId(GetZoneId(zoneIndex))
 end
-
 
 ------------------------------------------------------------------------
 -- 	Addon/Librray load functions

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -915,7 +915,7 @@ end
 --end
 
 -->return: number: parentZoneId
-function lib:GetZoneGeogrphicalParentZoneId(zoneId)
+function lib:GetZonGeographicalParentZoneId(zoneId)
 	local parentZoneId = lib.adjustedParentZoneIds[zoneId]
 	if not parentZoneId then
 		parentZoneId = lib:GetZoneMapPinInfo(zoneId)
@@ -925,15 +925,15 @@ function lib:GetZoneGeogrphicalParentZoneId(zoneId)
 end
 
 -->return: number: parentMapId
-function lib:GetZoneGeogrphicalParentMapId(zoneId)
-	local parentZoneId = lib:GetZoneGeogrphicalParentZoneId(zoneId)
+function lib:GetZoneGeographicalParentMapId(zoneId)
+	local parentZoneId = lib:GetZoneGeographicalParentZoneId(zoneId)
 	return GetMapIdByZoneId(parentZoneId)
 end
 
 -->return: number: parentMapId
-function lib:GetGeogrphicalParentMapId(mapId)
+function lib:GetGeographicalParentMapId(mapId)
 	local zoneIndex, = select(4, GetMapInfoById(mapId))
-	return lib:GetZoneGeogrphicalParentMapId(GetZoneId(zoneIndex))
+	return lib:GetZoneGeographicalParentMapId(GetZoneId(zoneIndex))
 end
 
 

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -374,23 +374,12 @@ function lib:GetAllZoneDataById(reBuildNew, doReloadUI)
                         zoneDataForId.parentZone = zoneParentIdOfZoneId
                     end
                 end
-				-- Get parentMapZoneId and pinInfo.
-				-- pinInfo is table of map pin indices {poiIndex = number, poiZoneIndex = number}
-				local parentMapZoneId, pinInfo = getPinInfo(zoneId, zoneDataForId.parentZone)
-				-- If pinInfo then add it to zone data.
-				if pinInfo and zoneDataForId.pinInfo == nil then
-					zoneDataForId.pinInfo = pinInfo
-				end
-				-- The parentMapZoneId is based on geographical location.
-				if zoneDataForId.parentMapZoneId == nil then
-					zoneDataForId.parentMapZoneId = parentMapZoneId
-				end
-				-- Get mapInfo.
-				local mapInfo = getMapInfo(zoneId)
-				-- If mapInfo then add it to zone data.
-				if mapInfo then
-					zoneDataForId.mapInfo = mapInfo
-				end
+		-- Get mapInfo.
+		local mapInfo = getMapInfo(zoneId)
+		-- If mapInfo then add it to zone data.
+		if mapInfo then
+			zoneDataForId.mapInfo = mapInfo
+		end
             end
         end
     end

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -939,7 +939,7 @@ end
 
 -->return: number: parentMapId
 function lib:GetGeographicalParentMapId(mapId)
-	local zoneIndex, = select(4, GetMapInfoById(mapId))
+	local zoneIndex = select(4, GetMapInfoById(mapId))
 	return lib:GetZoneGeographicalParentMapId(GetZoneId(zoneIndex))
 end
 

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -915,7 +915,8 @@ end
 --end
 
 -->return: number: parentZoneId
-function lib:GetZonGeographicalParentZoneId(zoneId)
+function lib:GetZoneGeographicalParentZoneId(zoneId)
+	if zoneId == nil or type(zoneId) ~= 'number' then return end
 	local zoneInfo = lib.adjustedParentMultiZoneIds[zoneId]
 	
 	if zoneInfo then
@@ -933,12 +934,14 @@ end
 
 -->return: number: parentMapId
 function lib:GetZoneGeographicalParentMapId(zoneId)
+	if zoneId == nil or type(zoneId) ~= 'number' then return end
 	local parentZoneId = lib:GetZoneGeographicalParentZoneId(zoneId)
 	return GetMapIdByZoneId(parentZoneId)
 end
 
 -->return: number: parentMapId
 function lib:GetGeographicalParentMapId(mapId)
+	if mapId == nil or type(mapId) ~= 'number' then return end
 	local zoneIndex = select(4, GetMapInfoById(mapId))
 	return lib:GetZoneGeographicalParentMapId(GetZoneId(zoneIndex))
 end

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -38,6 +38,7 @@ local clientLang = lib.currentClientLanguage
 local isAddonDevOfLibZone = (GetDisplayName() == '@Baertram' and true) or false
 
 local pubDungeons
+local poiDataTable
 
 ------------------------------------------------------------------------
 -- 	Helper functions

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -916,7 +916,14 @@ end
 
 -->return: number: parentZoneId
 function lib:GetZonGeographicalParentZoneId(zoneId)
-	local parentZoneId = lib.adjustedParentZoneIds[zoneId]
+	local zoneInfo = lib.adjustedParentMultiZoneIds[zoneId]
+	
+	if zoneInfo then
+		-- This zone exists in multiple zones, if player is in parent zone then use it or use first entry.
+		local currentZoneId = GetUnitWorldPosition("player")
+		parentZoneId = zoneInfo[currentZoneId] or select(2, next(zoneInfo))
+	end
+	
 	if not parentZoneId then
 		parentZoneId = lib:GetZoneMapPinInfo(zoneId)
 	end

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -927,7 +927,13 @@ end
 -->return: number: parentMapId
 function lib:GetZoneGeogrphicalParentMapId(zoneId)
 	local parentZoneId = lib:GetZoneGeogrphicalParentZoneId(zoneId)
-	
+	return GetMapIdByZoneId(parentZoneId)
+end
+
+-->return: number: parentMapId
+function lib:GetGeogrphicalParentMapId(mapId)
+	local zoneIndex, = select(4, GetMapInfoById(mapId))
+	local parentZoneId = lib:GetZoneGeogrphicalParentZoneId(GetZoneId(zoneIndex))
 	return GetMapIdByZoneId(parentZoneId)
 end
 

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -921,7 +921,7 @@ function lib:GetZonGeographicalParentZoneId(zoneId)
 	if zoneInfo then
 		-- This zone exists in multiple zones, if player is in parent zone then use it or use first entry.
 		local currentZoneId = GetUnitWorldPosition("player")
-		parentZoneId = zoneInfo[currentZoneId] or select(2, next(zoneInfo))
+		parentZoneId = zoneInfo[currentZoneId] or next(zoneInfo)
 	end
 	
 	if not parentZoneId then

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -169,8 +169,6 @@ local function buildPoiDataTable()
 				local entry = {
 					poiIndex = poiIndex,
 					poiZoneIndex = zoneIndexOfZoneId, -- the parent zoneIndex
-					poiName = poiName .. ' --> debug only', -- poiName
-					parentZoneName = GetZoneNameById(zoneId) .. ' --> debug only',
 				}
 				poiName = ZO_CachedStrFormat(SI_ZONE_NAME, poiName):lower()
 				if poiDataTable[poiName] and poiName:find(' i$') ~= nil then

--- a/LibZone/LibZone.lua
+++ b/LibZone/LibZone.lua
@@ -860,12 +860,12 @@ function lib:GetZoneMapPinInfo(zoneId, parentZoneId)
 	if zoneId == nil or type(zoneId) ~= 'number' then return end
 	parentZoneId = parentZoneId or GetParentZoneId(zoneId)
 	
+	local poiInfo
 	local zoneInfo = self.zoneData[zoneId]
 	if not zoneInfo then return end
 	local mapInfo = zoneInfo.mapInfo
 	if mapInfo then
 		-- Try to get pinInfo using parentZoneId
-		local poiInfo
 		if parentZoneId then
 			poiInfo = mapInfo[parentZoneId]
 		end
@@ -874,8 +874,8 @@ function lib:GetZoneMapPinInfo(zoneId, parentZoneId)
 			-- These zones also only have 1 entry.
 			parentZoneId, poiInfo = next(mapInfo) --> where parentZoneId is where the zone's map pin exists on.
 		end
-		return parentZoneId, poiInfo
 	end
+	return parentZoneId, poiInfo
 end
 
 --Example: -->can be removed or reduced<--

--- a/LibZone/LibZone_Data.lua
+++ b/LibZone/LibZone_Data.lua
@@ -331,8 +331,8 @@ lib.adjustedParentZoneIds = {
 -- used for current player zoneId
 lib.adjustedParentMultiZoneIds = {
 	[385] = { -- Ragnthar
-		[58] = , -- Malabal Tor
-		[101] = , -- Eastmarch
-		[104] = , -- Alik'r Desert
+		[58] = true, -->> Malabal Tor
+		[101] = true, -->> Eastmarch
+		[104] = true, -->> Alik'r Desert
 	}
 }

--- a/LibZone/LibZone_Data.lua
+++ b/LibZone/LibZone_Data.lua
@@ -279,3 +279,25 @@ removeNonLiveAPIVersionEntriesFromLibZoneData()
 --Provide this translated data to the global library variable
 lib.preloadedZoneNames = preloadedZoneNames
 
+
+--Localized "Wayshrine" string used to exclude wayshrine map pins.
+lib.wayshrineString = GetString(SI_DEATH_PROMPT_WAYSHRINE)
+
+-- This table contains parentZoneId modifiers for select zones.
+lib.geographicalParentZoneIds = {
+	[678] = 181, -- Imperial City Prison, force the use of Cyrodiil
+	[688] = 181, -- White-Gold Tower, force the use of Cyrodiil
+	[1027] = 1027, -- Artaeum. Normally is Summerset.
+	[1283] = 1283, -- The Shambles. Normally is Fargrave  City District.
+--	[1283] = 1283, -- Fargrave. set to use Faregrave instead of Fargrave City District.
+	
+	-- The parentZoneId for the following normally are the same as zoneId.
+	[1005] = 823, -- Linchal Grand Manor
+	[1108] = 726, -- Lakemire Xanmeer Manor.
+	[1200] = 92, -- Thieves' Oasis.
+	[1264] = 1207, -- Stone Eagle Aerie
+	[1109] = 101, -- Enchanted Snow Globe
+	[1125] = 101, -- Frostvault Chasm
+}
+
+

--- a/LibZone/LibZone_Data.lua
+++ b/LibZone/LibZone_Data.lua
@@ -313,9 +313,26 @@ lib.poiRefrenceTable = {
 		["poiZoneIndex"] = 500,
 	},
 }
+		
+					
+local allianceZones = {
+    [ALLIANCE_ALDMERI_DOMINION] = 381,
+    [ALLIANCE_EBONHEART_PACT] = 41,
+    [ALLIANCE_DAGGERFALL_COVENANT] = 3,
+}
 
 lib.adjustedParentZoneIds = {
+	[199] = allianceZones[GetUnitAlliance("player")], -- The Harborage --> Player alliance home
+	[689] = 684, -- Nikolvara's Kennel --> Wrothgar
 	[678] = 584, -- Imperial City Prison --> Imperial City
 	[688] = 584, -- White-Gold Tower --> Imperial City
 	[1209] = 1208, -- Gloomreach --> Blackreach: Arkthzand Cavern
+}
+-- used for current player zoneId
+lib.adjustedParentMultiZoneIds = {
+	[385] = { -- Ragnthar
+		[58] = , -- Malabal Tor
+		[101] = , -- Eastmarch
+		[104] = , -- Alik'r Desert
+	}
 }

--- a/LibZone/LibZone_Data.lua
+++ b/LibZone/LibZone_Data.lua
@@ -280,24 +280,36 @@ removeNonLiveAPIVersionEntriesFromLibZoneData()
 lib.preloadedZoneNames = preloadedZoneNames
 
 
+
 --Localized "Wayshrine" string used to exclude wayshrine map pins.
 lib.wayshrineString = GetString(SI_DEATH_PROMPT_WAYSHRINE)
 
--- This table contains parentZoneId modifiers for select zones.
-lib.geographicalParentZoneIds = {
-	[678] = 181, -- Imperial City Prison, force the use of Cyrodiil
-	[688] = 181, -- White-Gold Tower, force the use of Cyrodiil
-	[1027] = 1027, -- Artaeum. Normally is Summerset.
-	[1283] = 1283, -- The Shambles. Normally is Fargrave  City District.
---	[1283] = 1283, -- Fargrave. set to use Faregrave instead of Fargrave City District.
-	
-	-- The parentZoneId for the following normally are the same as zoneId.
-	[1005] = 823, -- Linchal Grand Manor
-	[1108] = 726, -- Lakemire Xanmeer Manor.
-	[1200] = 92, -- Thieves' Oasis.
-	[1264] = 1207, -- Stone Eagle Aerie
-	[1109] = 101, -- Enchanted Snow Globe
-	[1125] = 101, -- Frostvault Chasm
+--This table is used to get the poiName from poi indices in order to match with the poiData.
+--[zoneId]{ -- reason
+--		["poiIndex"] = number,
+--		["poiZoneIndex"] = number,
+--},
+lib.poiRefrenceTable = {
+			-- zoneName -- poiName
+	[469] = { -- Tomb of Apostates -- Tomb of the Apostates
+		["poiIndex"] = 35,
+		["poiZoneIndex"] = 11,
+	},
+	[913] = { -- The Mage's Staff -- Spellscar
+		["poiIndex"] = 9,
+		["poiZoneIndex"] = 500,
+	},
+	[910] = { -- Elinhir Sewerworks -- Elinhir -- Closest pin to use since Elinhir is not a zone.
+		["poiIndex"] = 8,
+		["poiZoneIndex"] = 500,
+	},
+	[677] = { -- Maelstrom Arena -- Arena: Maelstrom
+		["poiIndex"] = 55,
+		["poiZoneIndex"] = 379,
+	},
+			-- Parent map is an internal zone, use parent's parent
+	[915] = { -- Skyreach Temple. Located inside Loth'Na Caverns. This will point to Loth'Na Caverns to show where it is.
+		["poiIndex"] = 18,
+		["poiZoneIndex"] = 500,
+	},
 }
-
-

--- a/LibZone/LibZone_Data.lua
+++ b/LibZone/LibZone_Data.lua
@@ -313,3 +313,9 @@ lib.poiRefrenceTable = {
 		["poiZoneIndex"] = 500,
 	},
 }
+
+lib.adjustedParentZoneIds = {
+	[678] = 584, -- Imperial City Prison --> Imperial City
+	[688] = 584, -- White-Gold Tower --> Imperial City
+	[1209] = 1208, -- Gloomreach --> Blackreach: Arkthzand Cavern
+}


### PR DESCRIPTION
I rebuilt poi matching and how the data is stored.
Now all pins for a zone are stored. This is for zones that exists on more than one zones. A specific parent can be chosen when using lib:GetZoneMapPinInfo.

Now pinInfo is acquired using lib:GetZoneMapPinInfo(zoneId, parentZoneId)
If the selected one has a map pin on it's parent, the pinInfo and, adjusted if needed, parentZoneId.
Below the function, I added how I am using this function and info as an example.